### PR TITLE
fix: clothes 속성 관련 테이블 유니크,index 제약 추가 & 컬럼 이름 변경 & cloth -> clothes로 변경

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -69,34 +69,38 @@ CREATE TABLE IF NOT EXISTS tbl_clothes
 );
 
 -- 의상 속성 테이블
-CREATE TABLE IF NOT EXISTS tbl_cloth_attributes
+CREATE TABLE IF NOT EXISTS tbl_clothes_attributes
 (
     id                        UUID                     PRIMARY KEY,
     name                      VARCHAR(50)              NOT NULL,
-    created_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    created_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    -- constraints
+    CONSTRAINT ux_attr_name UNIQUE (name)
 );
 
--- 의상 선택적 하위 속성 테이블
-CREATE TABLE IF NOT EXISTS tbl_cloth_attributes_defs
+-- 의상 선택지 정의 테이블(카테고리별 허용 값)
+CREATE TABLE IF NOT EXISTS tbl_clothes_attributes_defs
 (
     id                        UUID                     PRIMARY KEY,
     attribute_id              UUID                     NOT NULL,
-    values                    VARCHAR(50),
+    att_def                   VARCHAR(50)              NOT NULL,
     created_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     -- constraints
-    CONSTRAINT fk_attributes_defs_attr FOREIGN KEY (attribute_id) REFERENCES tbl_cloth_attributes (id) ON DELETE CASCADE
+    CONSTRAINT fk_attributes_defs_attr FOREIGN KEY (attribute_id) REFERENCES tbl_clothes_attributes (id) ON DELETE CASCADE,
+    CONSTRAINT ux_attrdef_attr_attdef UNIQUE (attribute_id, att_def)
 );
 
 -- 의상 속성 값 연결 테이블
-CREATE TABLE IF NOT EXISTS tbl_cloth_attributes_values
+CREATE TABLE IF NOT EXISTS tbl_clothes_attributes_values
 (
     id                        UUID PRIMARY KEY,
     clothes_id                UUID NOT NULL,
     attributes_id             UUID NOT NULL,
-    def_value          VARCHAR(50),
+    def_value                 VARCHAR(50) NOT NULL,
     -- constraints
     CONSTRAINT fk_attr_values_clothes FOREIGN KEY (clothes_id) REFERENCES tbl_clothes (id) ON DELETE CASCADE,
-    CONSTRAINT fk_attr_values_attr FOREIGN KEY (attributes_id) REFERENCES tbl_cloth_attributes (id) ON DELETE CASCADE
+    CONSTRAINT fk_attr_values_attr FOREIGN KEY (attributes_id) REFERENCES tbl_clothes_attributes (id) ON DELETE CASCADE,
+    CONSTRAINT uk_cav_clothes_attribute UNIQUE (clothes_id, attributes_id)
 );
 
 /****** 피드 ******/
@@ -211,6 +215,12 @@ CREATE INDEX idx_tbl_locations_lat_lon
 -- tbl_clothes index
 CREATE INDEX idx_tbl_clothes_owner_id
     ON tbl_clothes (owner_id);
+
+CREATE INDEX IF NOT EXISTS ix_cav_clothes_attr
+    ON tbl_clothes_attributes_values (clothes_id, attributes_id);
+
+CREATE INDEX IF NOT EXISTS ix_cav_attr_defvalue
+    ON tbl_clothes_attributes_values (attributes_id, def_value);
 
 /* tbl_profiles - name 컬럼 추가 & 수정 */
 


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- clothes 속성 관련 테이블 유니크,index 제약 추가 
- 컬럼 이름 변경 
- 테이블 이름 cloth -> clothes로 변경

## 🛠️ PR 변경 사항
<!-- 어떤 변경 사항이 있나요? -->
- 


## 📸스크린샷 (선택)
<!-- 관련 스크린샷을 첨부해 주세요 -->

## 💬 공유사항
DB 수정하실분들은 @Leichtstar 이 올려주신 patch 파일 한번 돌리면 될것같습니다. 
https://discord.com/channels/1401718975376654437/1401718976307920908/1416954766495580170 

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [ ]  기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [ ]  예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
- DB 전체 드롭하고 재생성해봤습니다 잘됨!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 프로필에 이름 필드가 추가되어 표시되며, 비어 있을 수 없습니다.
- Bug Fixes
  - 의류 속성에서 중복 항목과 비어 있는 값이 저장되지 않도록 검증을 강화했습니다.
- Performance
  - 의류 속성 조회·필터링 속도를 개선했습니다.
- Refactor
  - 의류 속성 관련 명칭을 일관되게 정리하여 사용성을 향상했습니다.
- Chores
  - 기존 사용자 이름을 프로필 이름으로 이전하는 데이터 마이그레이션을 수행했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->