### PR TITLE
feat: 임시 비밀번호 발급 및 비밀번호 재설정 코드 구현 

### DIFF
--- a/src/main/java/com/sprint/ootd5team/base/eventlistener/UserEventListener.java
+++ b/src/main/java/com/sprint/ootd5team/base/eventlistener/UserEventListener.java
@@ -3,6 +3,7 @@ package com.sprint.ootd5team.base.eventlistener;
 import com.sprint.ootd5team.domain.user.dto.TemporaryPasswordCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
@@ -14,6 +15,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class UserEventListener {
 
+    @Value("${ootd.email.sender}")
+    private String sender;
+
     private final JavaMailSender mailSender;
 
     @Async("eventTaskExecutor")
@@ -22,7 +26,7 @@ public class UserEventListener {
         log.info("임시 비밀번호 메일 발송 이벤트 시작 email:{}",event.email());
 
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom("sprtms5335@gmail.com");
+        message.setFrom(sender);
         message.setTo(event.email());
         message.setSubject("임시 비밀번호 발급 - OTBOO");
         // 본문 구성

--- a/src/main/java/com/sprint/ootd5team/base/eventlistener/UserEventListener.java
+++ b/src/main/java/com/sprint/ootd5team/base/eventlistener/UserEventListener.java
@@ -1,8 +1,38 @@
 package com.sprint.ootd5team.base.eventlistener;
 
+import com.sprint.ootd5team.domain.user.dto.TemporaryPasswordCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
+@Slf4j
+@RequiredArgsConstructor
 public class UserEventListener {
 
+    private final JavaMailSender mailSender;
+
+    @Async("eventTaskExecutor")
+    @TransactionalEventListener
+    public void on(TemporaryPasswordCreatedEvent event){
+        log.info("임시 비밀번호 메일 발송 이벤트 시작 email:{}",event.email());
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("sprtms5335@gmail.com");
+        message.setTo(event.email());
+        message.setSubject("[OOTD] 임시 비밀번호 안내");
+        message.setText("안녕하세요, " + event.name() + "님.\n\n"
+            + "임시 비밀번호는 아래와 같습니다:\n\n"
+            + event.tempPassword() + "\n\n"
+            + "해당 비밀번호는 3분 동안만 유효합니다.\n"
+            + "로그인 후 반드시 새 비밀번호로 변경해주세요.");
+        mailSender.send(message);
+
+
+        log.info("임시 비밀번호 메일 발송 이벤트 완료 email:{}",event.email());
+    }
 }

--- a/src/main/java/com/sprint/ootd5team/base/eventlistener/UserEventListener.java
+++ b/src/main/java/com/sprint/ootd5team/base/eventlistener/UserEventListener.java
@@ -24,12 +24,24 @@ public class UserEventListener {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom("sprtms5335@gmail.com");
         message.setTo(event.email());
-        message.setSubject("[OOTD] 임시 비밀번호 안내");
-        message.setText("안녕하세요, " + event.name() + "님.\n\n"
-            + "임시 비밀번호는 아래와 같습니다:\n\n"
-            + event.tempPassword() + "\n\n"
-            + "해당 비밀번호는 3분 동안만 유효합니다.\n"
-            + "로그인 후 반드시 새 비밀번호로 변경해주세요.");
+        message.setSubject("임시 비밀번호 발급 - OTBOO");
+        // 본문 구성
+        String body =
+            "OTBOO\n"
+                + "임시 비밀번호가 발급되었습니다\n\n"
+                + "안녕하세요, " + event.name() + "님!\n\n"
+                + "요청하신 임시 비밀번호가 발급되었습니다. "
+                + "아래 임시 비밀번호를 사용하여 로그인 후 새로운 비밀번호로 변경해주세요.\n\n"
+                + "임시 비밀번호\n"
+                + event.tempPassword() + "\n\n"
+                + "⚠️ 중요 안내사항\n"
+                + "• 이 임시 비밀번호는 " + event.expireAt() + " 까지만 유효합니다\n"
+                + "• 보안을 위해 로그인 후 즉시 새로운 비밀번호로 변경해주세요\n"
+                + "• 임시 비밀번호는 다른 사람과 공유하지 마세요\n\n"
+                + "본 메일은 발신전용이므로 회신되지 않습니다.\n"
+                + "문의사항이 있으시면 고객센터로 연락해주세요.";
+
+        message.setText(body);
         mailSender.send(message);
 
 

--- a/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
+++ b/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
         userRepository.save(user);
 
         // 이벤트 리스너를 통해 비동기로 메일 보내기를 처리함
-        eventPublisher.publishEvent(new TemporaryPasswordCreatedEvent(user.getTempPassword(),user.getEmail(),user.getName()));
+        eventPublisher.publishEvent(new TemporaryPasswordCreatedEvent(user.getTempPassword(),user.getEmail(),user.getName(),user.getTempPasswordExpireAt()));
     }
 
     /**

--- a/src/main/java/com/sprint/ootd5team/domain/user/dto/TemporaryPasswordCreatedEvent.java
+++ b/src/main/java/com/sprint/ootd5team/domain/user/dto/TemporaryPasswordCreatedEvent.java
@@ -1,0 +1,7 @@
+package com.sprint.ootd5team.domain.user.dto;
+
+public record TemporaryPasswordCreatedEvent(
+  String tempPassword,
+  String email,
+  String name
+){}

--- a/src/main/java/com/sprint/ootd5team/domain/user/dto/TemporaryPasswordCreatedEvent.java
+++ b/src/main/java/com/sprint/ootd5team/domain/user/dto/TemporaryPasswordCreatedEvent.java
@@ -1,7 +1,10 @@
 package com.sprint.ootd5team.domain.user.dto;
 
+import java.time.Instant;
+
 public record TemporaryPasswordCreatedEvent(
   String tempPassword,
   String email,
-  String name
+  String name,
+  Instant expireAt
 ){}

--- a/src/main/java/com/sprint/ootd5team/domain/user/dto/UserPasswordUpdateEvent.java
+++ b/src/main/java/com/sprint/ootd5team/domain/user/dto/UserPasswordUpdateEvent.java
@@ -1,5 +1,0 @@
-package com.sprint.ootd5team.domain.user.dto;
-
-public record UserPasswordUpdateEvent (
-  String email
-){}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,6 +47,9 @@ ootd:
     username: ${OOTD_ADMIN_USERNAME}
     password: ${OOTD_ADMIN_PASSWORD}
     email: ${OOTD_ADMIN_EMAIL}
+    # 임시 비밀번호 전송하는 이메일 설정
+  email:
+    sender: ${OOTD_EMAIL_SENDER}
 
   # Access Token 및 Refresh Token 비밀키, 만료시간 설정
   jwt:


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 변경 사항
<!-- 어떤 변경 사항이 있나요? -->
- 임시 비밀번호 발급 및 비밀번호 재설정 코드 구현 
<img width="2272" height="726" alt="1" src="https://github.com/user-attachments/assets/fa59750f-c8de-4307-8480-b75ff885d4a6" />
<img width="822" height="406" alt="2" src="https://github.com/user-attachments/assets/477fbd5b-5eaf-4296-89a4-58b0927562a5" />
<img width="1584" height="817" alt="3" src="https://github.com/user-attachments/assets/9760acab-3406-4d30-b83b-6c9d15a0a590" />


## 📸스크린샷 (선택)
<!-- 관련 스크린샷을 첨부해 주세요 -->


## 💬 공유사항
<!-- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x]  기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [x]  예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트

- [ ]  테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [ ]  실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 임시 비밀번호 발급 시 발송되는 이메일에 사용자 이름, 임시 비밀번호, 만료 시각을 명확히 표기해 안내가 강화되었습니다. 사용자는 메일만으로 만료 시간까지 쉽게 확인할 수 있습니다.
- 리팩터
  - 비밀번호 재설정 이메일 발송을 비동기 처리로 전환하여 응답 속도가 빨라지고 전송 안정성이 개선되었습니다. 대량 트래픽 상황에서도 보다 안정적으로 메일이 전송되며, 발송 시작·완료 로깅 강화로 장애 대응성도 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->