### PR TITLE
refactor: 의상속성 예외처리에 커스텀Exception 적용

### DIFF
--- a/src/main/java/com/sprint/ootd5team/base/errorcode/ErrorCode.java
+++ b/src/main/java/com/sprint/ootd5team/base/errorcode/ErrorCode.java
@@ -33,6 +33,12 @@ public enum ErrorCode {
     // Clothes 관련 에러코드
     CLOTHES_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 의상 입니다."),
 
+    // ClothesAttribute 관련 에러코드
+    ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 속성입니다."),
+    ATTRIBUTE_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 속성입니다."),
+    INVALID_ATTRIBUTE_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 속성명입니다.")
+
+
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/AttributeAlreadyExistException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/AttributeAlreadyExistException.java
@@ -1,0 +1,21 @@
+package com.sprint.ootd5team.base.exception.clothesattribute;
+
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+import java.util.UUID;
+
+public class AttributeAlreadyExistException extends AttributeException {
+    public AttributeAlreadyExistException() {
+        super(ErrorCode.ATTRIBUTE_ALREADY_EXIST);
+    }
+
+    public static AttributeAlreadyExistException withId(UUID id) {
+        AttributeAlreadyExistException exception = new AttributeAlreadyExistException();
+        exception.addDetail("attributeId", id);
+        return exception;
+    }
+    public static AttributeAlreadyExistException withName(String name) {
+        AttributeAlreadyExistException exception = new AttributeAlreadyExistException();
+        exception.addDetail("name", name);
+        return exception;
+    }
+}

--- a/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/AttributeException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/AttributeException.java
@@ -1,0 +1,16 @@
+package com.sprint.ootd5team.base.exception.clothesattribute;
+
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+import com.sprint.ootd5team.base.exception.OotdException;
+
+public class AttributeException extends OotdException {
+
+    public AttributeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AttributeException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+}

--- a/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/AttributeNotFoundException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/AttributeNotFoundException.java
@@ -1,0 +1,17 @@
+package com.sprint.ootd5team.base.exception.clothesattribute;
+
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+import java.util.UUID;
+
+public class AttributeNotFoundException extends AttributeException {
+
+    public AttributeNotFoundException() {
+        super(ErrorCode.ATTRIBUTE_NOT_FOUND);
+    }
+
+    public static AttributeNotFoundException withId(UUID attributeId) {
+        AttributeNotFoundException exception = new AttributeNotFoundException();
+        exception.addDetail("attributeId", attributeId);
+        return exception;
+    }
+}

--- a/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/InvalidAttributeException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/clothesattribute/InvalidAttributeException.java
@@ -1,0 +1,10 @@
+package com.sprint.ootd5team.base.exception.clothesattribute;
+
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+
+public class InvalidAttributeException extends AttributeException {
+
+	public InvalidAttributeException() {
+		super(ErrorCode.INVALID_ATTRIBUTE_NAME);
+	}
+}

--- a/src/main/java/com/sprint/ootd5team/domain/clothattribute/entity/ClothesAttribute.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothattribute/entity/ClothesAttribute.java
@@ -49,7 +49,6 @@ public class ClothesAttribute extends BaseEntity {
 //		for (var it = defs.iterator(); it.hasNext(); ) {
 //			ClothesAttributeDef def = it.next();
 //			it.remove();           // ✔ orphanRemoval 트리거
-//			def.setAttribute(null);  // 양방향 정합성 유지(없어도 orphanRemoval이면 삭제됨)
 //		}
 //
 //		// 2) 새 자식들 추가 (양방향 세팅)
@@ -67,7 +66,6 @@ public class ClothesAttribute extends BaseEntity {
 //	// def 제거
 //	public void removeDef(ClothesAttributeDef def) {
 //		defs.remove(def);
-//		def.setAttribute(null);
 //	}
 
 	// def전부 비우기
@@ -75,7 +73,6 @@ public class ClothesAttribute extends BaseEntity {
 		for (var it = defs.iterator(); it.hasNext(); ) {
 			ClothesAttributeDef def = it.next();
 			it.remove();
-			def.setAttribute(null);
 		}
 	}
 }

--- a/src/main/java/com/sprint/ootd5team/domain/clothattribute/entity/ClothesAttributeDef.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothattribute/entity/ClothesAttributeDef.java
@@ -1,6 +1,7 @@
 package com.sprint.ootd5team.domain.clothattribute.entity;
 
 import com.sprint.ootd5team.base.entity.BaseEntity;
+import com.sprint.ootd5team.base.exception.clothesattribute.InvalidAttributeException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -39,6 +40,7 @@ public class ClothesAttributeDef extends BaseEntity {
 		this.attDef = attDef;
 	}
 	void setAttribute(ClothesAttribute attribute){
+		if(attribute == null){throw new InvalidAttributeException();}
 		this.attribute = attribute;
 	}
 }

--- a/src/main/java/com/sprint/ootd5team/domain/clothattribute/service/BasicClothesAttributeService.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothattribute/service/BasicClothesAttributeService.java
@@ -1,5 +1,8 @@
 package com.sprint.ootd5team.domain.clothattribute.service;
 
+import com.sprint.ootd5team.base.exception.clothesattribute.AttributeAlreadyExistException;
+import com.sprint.ootd5team.base.exception.clothesattribute.AttributeNotFoundException;
+import com.sprint.ootd5team.base.exception.clothesattribute.InvalidAttributeException;
 import com.sprint.ootd5team.domain.clothattribute.dto.ClothesAttributeDefCreateRequest;
 import com.sprint.ootd5team.domain.clothattribute.dto.ClothesAttributeDefDto;
 import com.sprint.ootd5team.domain.clothattribute.dto.ClothesAttributeDefUpdateRequest;
@@ -12,7 +15,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.Comparator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +36,7 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 	@Override
 	@Transactional
 	public ClothesAttributeDefDto create(ClothesAttributeDefCreateRequest request) {
-		log.debug("의상 속성,하위속성 생성 시작.");
+		log.debug("[ClothesAttributeService] 의상 속성,하위속성 생성 시작.");
 
 		// 속성 엔티티 생성(부모 엔티티)
 		ClothesAttribute createdAttribute = new ClothesAttribute(request.name());
@@ -49,24 +51,25 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 
 		// 유효값 검증
 		if (request.name() == null || request.name().isBlank()) {
-			throw new IllegalArgumentException("속성명은 비어 있을 수 없습니다.");
+			throw new InvalidAttributeException();
 		}
 		if (clothesAttributeRepository.existsByNameIgnoreCase(request.name())) {
-			throw new IllegalStateException("이미 존재하는 속성명입니다: " + request.name());
+			throw AttributeAlreadyExistException.withName(request.name());
 		}
 		// 영속화
 		ClothesAttribute saved = clothesAttributeRepository.save(createdAttribute);
-		log.info("의상 속성 생성됨 : 속성명={}, 하위속성 수={}", saved.getName(), saved.getDefs().size());
+		log.info("[ClothesAttributeService] 의상 속성 생성됨 : 속성명={}, 하위속성 수={}", saved.getName(), saved.getDefs().size());
 		return mapper.toDto(saved);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public List<ClothesAttributeDefDto> findAll(String sortBy, String sortDirection, String keywordLike) {
+		log.debug("[ClothesAttributeService] 전체 속성&하위속성 검색,정렬조회 시작.");
 		List<ClothesAttributeDefDto> all = clothesAttributeRepository.findAll().stream()
 			.map(mapper::toDto)
 			.toList();
-
+		int attTotalSize = all.size();
 		// 1. 검색
 		if (keywordLike != null && !keywordLike.isBlank()) {
 			all = all.stream()
@@ -83,18 +86,19 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 		if ("DESCENDING".equalsIgnoreCase(sortDirection)) {
 			comparator = comparator.reversed();
 		}
-
-		return all.stream().sorted(comparator).toList();
+		List<ClothesAttributeDefDto> result = all.stream().sorted(comparator).toList();
+		log.info("[ClothesAttributeService] 전체 속성&하위속성 검색,정렬조회 성공: 전체 속성 수= {}rows, 검색된 속성 수={}rows ", attTotalSize, result.size());
+		return result;
 	}
 
 	@Override
 	@Transactional
 	public ClothesAttributeDefDto update(UUID id, ClothesAttributeDefUpdateRequest request) {
-		log.debug("의상 속성,하위속성 수정 시작.");
+		log.debug("[ClothesAttributeService] 의상 속성,하위속성 수정 시작.");
 
 		// 대상 속성 엔티티 특정
 		ClothesAttribute targetAttribute = clothesAttributeRepository.findById(id)
-			.orElseThrow(() -> new NoSuchElementException("존재하지 않는 AttributeId입니다"));
+			.orElseThrow(AttributeNotFoundException::new);
 
 		// 업데이트 속성명 전처리
 		String newName = request.name() != null ? request.name().trim() : "";
@@ -108,10 +112,10 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 
 		// 유효성 검증
 		if (newName.isBlank()) {
-			throw new IllegalArgumentException("속성명은 비어 있을 수 없습니다.");
+			throw new InvalidAttributeException();
 		}
 		if ((!targetAttribute.getName().equalsIgnoreCase(newName)) && clothesAttributeRepository.existsByNameIgnoreCase(newName)) {
-			throw new IllegalStateException("이미 존재하는 속성명입니다: " + newName);
+			throw AttributeAlreadyExistException.withName(newName);
 		}
 
 		// 새로운 값으로 갱신
@@ -124,7 +128,7 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 
 		// 영속화
 		ClothesAttribute saved = clothesAttributeRepository.save(targetAttribute);
-		log.info("의상 속성 수정됨 : 속성명={}, 하위속성 수={}", saved.getName(), saved.getDefs().size());
+		log.info("[ClothesAttributeService] 의상 속성 수정됨 : 속성명={}, 하위속성 수={}", saved.getName(), saved.getDefs().size());
 		return mapper.toDto(saved);
 	}
 
@@ -132,7 +136,7 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 	@Transactional(readOnly = true)
 	public List<ClothesAttributeDto> getValuesByAttributeId(UUID attributeId) {
 		ClothesAttribute attribute = clothesAttributeRepository.findById(attributeId)
-			.orElseThrow(() -> new IllegalArgumentException("속성을 찾을 수 없음: " + attributeId));
+			.orElseThrow(AttributeNotFoundException::new);
 
 		// 자식 엔티티 → DTO 변환
 		return attribute.getDefs().stream()
@@ -143,11 +147,11 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 	@Override
 	@Transactional
 	public void delete(UUID id) {
-		log.debug("의상 속성,하위속성 제거 시작.");
+		log.debug("[ClothesAttributeService] 의상 속성,하위속성 제거 시작.");
 
 		// 대상 속성 엔티티 특정
 		ClothesAttribute targetAttribute = clothesAttributeRepository.findById(id)
-			.orElseThrow(() -> new NoSuchElementException("존재하지 않는 AttributeId입니다"));
+			.orElseThrow(AttributeNotFoundException::new);
 		//하위속성 제거
 		targetAttribute.clearDefs();
 		em.flush();
@@ -155,6 +159,6 @@ public class BasicClothesAttributeService implements ClothesAttributeService {
 		String deletedName = targetAttribute.getName();
 		clothesAttributeRepository.delete(targetAttribute);
 
-		log.info("의상 속성 제거됨: 속성명={}", deletedName);
+		log.info("[ClothesAttributeService] 의상 속성 제거됨: 속성명={}", deletedName);
 	}
 }

--- a/src/main/java/com/sprint/ootd5team/domain/clothes/service/ClothesServiceImpl.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothes/service/ClothesServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sprint.ootd5team.domain.clothes.service;
 
+import com.sprint.ootd5team.base.exception.clothesattribute.AttributeNotFoundException;
 import com.sprint.ootd5team.base.exception.file.FileSaveFailedException;
 import com.sprint.ootd5team.base.exception.user.UserNotFoundException;
 import com.sprint.ootd5team.base.storage.FileStorage;
@@ -139,8 +140,7 @@ public class ClothesServiceImpl implements ClothesService {
                 ClothesAttribute attr = attributeRepository.findById(dto.definitionId())
                     .orElseThrow(() -> {
                         log.error("[ClothesService] 속성 정의 없음: definitionId={}", dto.definitionId());
-                        throw new IllegalArgumentException("존재하지 않는 속성 정의");
-                        //TODO: return ClothesAttributeNotFoundException.withId(dto.definitionId());
+	                    return AttributeNotFoundException.withId(dto.definitionId());
                     });
 
                 validateAttributeValue(attr, dto.value());


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)
의상속성 도메인 커스텀 예외처리 작성

## 🛠️ PR 변경 사항
    ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 속성입니다."),
    ATTRIBUTE_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 속성입니다."),
    INVALID_ATTRIBUTE_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 속성명입니다.")

## 💬 공유사항
 - @hyohyo-zz ClothesServiceImpl에 TODO로 걸어둔 IllegalArgumentException을 커스텀 익셉션으로 대체했습니다.
  

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [ ]  기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [ ]  예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트

- [ ]  테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [ ]  실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)
