### PR TITLE
feat: url로 의상 정보 추출하기(웹크롤링 기반)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,11 +87,9 @@ dependencies {
 
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-}
-
 test {
+    useJUnitPlatform()
+    systemProperty "file.encoding", "UTF-8"
     finalizedBy jacocoTestReport
 }
 
@@ -106,7 +104,7 @@ clean {
 //QueryDsl : 자바 컴파일할때, 자동 생성된 Q 클래스를 querydslSrcDir 경로에 생성
 tasks.withType(JavaCompile) {
     options.generatedSourceOutputDirectory = file(querydslDir)
-
+    options.encoding = 'UTF-8'
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,8 @@ dependencies {
     //mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // 웹 스크래핑
+    implementation 'org.jsoup:jsoup:1.18.1'
 
 }
 

--- a/src/main/java/com/sprint/ootd5team/base/errorcode/ErrorCode.java
+++ b/src/main/java/com/sprint/ootd5team/base/errorcode/ErrorCode.java
@@ -10,8 +10,8 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자입니다."),
     INVALID_USER_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 사용자 인증 정보입니다."),
     UNSUPPORTED_PRINCIPAL(HttpStatus.UNAUTHORIZED, "지원하지 않는 사용자 인증 타입입니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST,"잘못된 토큰입니다."),
-    INVALID_USER_DETAILS(HttpStatus.BAD_REQUEST,"잘못된 유저 Details입니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다."),
+    INVALID_USER_DETAILS(HttpStatus.BAD_REQUEST, "잘못된 유저 Details입니다."),
 
     // User 관련 에러코드
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
@@ -39,20 +39,22 @@ public enum ErrorCode {
     FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "파일 크기 초과"),
 
     //기타 에러코드
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"알 수 없는 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다."),
 
     // Clothes 관련 에러코드
     CLOTHES_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 의상입니다."),
     CLOTHES_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "옷 저장에 실패했습니다."),
-
+    CLOTHES_EXTRACTION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "의상 정보 추출에 실패했습니다."),
 
     // ClothesAttribute 관련 에러코드
     ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 속성입니다."),
     ATTRIBUTE_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 속성입니다."),
     INVALID_ATTRIBUTE_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 속성명입니다."),
     CLOTHES_ATTRIBUTE_VALUE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않은 속성값입니다."),
-    INVALID_ATTRIBUTE(HttpStatus.BAD_REQUEST, "유효하지 않은 속성입니다.")
+    INVALID_ATTRIBUTE(HttpStatus.BAD_REQUEST, "유효하지 않은 속성입니다."),
 
+    // 웹 크롤링 관련 에러코드
+    SCRAPING_FAILED(HttpStatus.BAD_GATEWAY, "웹 스크래핑 실패"),
 
     ;
     private final HttpStatus status;

--- a/src/main/java/com/sprint/ootd5team/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/GlobalExceptionHandler.java
@@ -1,9 +1,13 @@
 package com.sprint.ootd5team.base.exception;
 
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+import com.sprint.ootd5team.base.exception.file.FileTooLargeException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -21,4 +25,16 @@ public class GlobalExceptionHandler {
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(new ErrorResponse(ex));
     }
+
+    /**
+     * Spring 전역에서 multipart 업로드 크기 초과 시 발생
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public void translateAndRethrow(MaxUploadSizeExceededException ex) {
+        throw FileTooLargeException.withSize(
+            -1, // 알 수 없음 placeholder,
+            ex.getMaxUploadSize()
+        );
+    }
+
 }

--- a/src/main/java/com/sprint/ootd5team/base/exception/clothes/ClothesExtractionFailedException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/clothes/ClothesExtractionFailedException.java
@@ -1,0 +1,16 @@
+package com.sprint.ootd5team.base.exception.clothes;
+
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+
+public class ClothesExtractionFailedException extends ClothesException {
+
+    public ClothesExtractionFailedException() {
+        super(ErrorCode.CLOTHES_EXTRACTION_FAILED);
+    }
+
+    public static ClothesExtractionFailedException withUrl(String targetUrl) {
+        ClothesExtractionFailedException exception = new ClothesExtractionFailedException();
+        exception.addDetail("targetUrl", targetUrl);
+        return exception;
+    }
+}

--- a/src/main/java/com/sprint/ootd5team/base/exception/file/FileTooLargeException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/file/FileTooLargeException.java
@@ -10,7 +10,7 @@ public class FileTooLargeException extends FileException {
 
     public static FileTooLargeException withSize(long fileSize, long maxSize) {
         FileTooLargeException exception = new FileTooLargeException();
-        exception.addDetail("fileSize", fileSize);
+        exception.addDetail("fileSize", fileSize == -1 ? "unknown" : fileSize);
         exception.addDetail("maxSize", maxSize);
         return exception;
     }

--- a/src/main/java/com/sprint/ootd5team/base/exception/jsoup/JsoupException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/jsoup/JsoupException.java
@@ -1,0 +1,15 @@
+package com.sprint.ootd5team.base.exception.jsoup;
+
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+import com.sprint.ootd5team.base.exception.OotdException;
+
+public class JsoupException extends OotdException {
+
+    public JsoupException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public JsoupException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/sprint/ootd5team/base/exception/jsoup/JsoupFetchException.java
+++ b/src/main/java/com/sprint/ootd5team/base/exception/jsoup/JsoupFetchException.java
@@ -1,0 +1,11 @@
+package com.sprint.ootd5team.base.exception.jsoup;
+
+import com.sprint.ootd5team.base.errorcode.ErrorCode;
+
+public class JsoupFetchException extends JsoupException {
+
+    public JsoupFetchException(String url, Throwable cause) {
+        super(ErrorCode.SCRAPING_FAILED, cause);
+        addDetail("url", url);
+    }
+}

--- a/src/main/java/com/sprint/ootd5team/base/jsoup/JsoupClient.java
+++ b/src/main/java/com/sprint/ootd5team/base/jsoup/JsoupClient.java
@@ -1,0 +1,20 @@
+package com.sprint.ootd5team.base.jsoup;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+/**
+ * Jsoup 라이브러리 호출을 감싸는 클라이언트
+ * url로 부터 html 문서를 가져와 Document 객체를 반환한다
+ * - 외부 HTTP 요청 + html 파싱 담당
+ * - 서비스/도메인에서 Jsoup 라이브러리 의존성을 최소화
+ * - 테스트 환경에서는 이 컴포넌트를 mock 처리하여 실제 HTTP요청 없이 파싱 동작 검증 가능
+ */
+@Component
+public class JsoupClient {
+
+    public Document get(String url) throws Exception {
+        return Jsoup.connect(url).get();
+    }
+}

--- a/src/main/java/com/sprint/ootd5team/base/jsoup/JsoupClient.java
+++ b/src/main/java/com/sprint/ootd5team/base/jsoup/JsoupClient.java
@@ -1,20 +1,77 @@
 package com.sprint.ootd5team.base.jsoup;
 
+import com.sprint.ootd5team.base.exception.jsoup.JsoupFetchException;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * Jsoup 라이브러리 호출을 감싸는 클라이언트
- * url로 부터 html 문서를 가져와 Document 객체를 반환한다
- * - 외부 HTTP 요청 + html 파싱 담당
- * - 서비스/도메인에서 Jsoup 라이브러리 의존성을 최소화
- * - 테스트 환경에서는 이 컴포넌트를 mock 처리하여 실제 HTTP요청 없이 파싱 동작 검증 가능
+ * Jsoup 기반 HTML fetch 클라이언트
+ *
+ * <p>외부 URL에서 HTML 문서를 가져와 {@link Document}를 반환
+ * <br>SSRF 방어를 위해 로컬/사설망/메타데이터 IP(127.0.0.1, 10.x.x.x, 169.254.169.254 등) 접근은 차단
+ *
+ * <p>설정값:
+ * <ul>
+ *   <li>{@code ootd.jsoup.timeout} – 요청 타임아웃(ms)</li>
+ *   <li>{@code ootd.jsoup.user-agent} – HTTP User-Agent</li>
+ * </ul>
  */
 @Component
 public class JsoupClient {
 
-    public Document get(String url) throws Exception {
-        return Jsoup.connect(url).get();
+    private final int timeoutMillis;
+    private final String userAgent;
+
+    public JsoupClient(
+        @Value("${ootd.jsoup.timeout}") int timeoutMillis,
+        @Value("${ootd.jsoup.user-agent}") String userAgent
+    ) {
+        this.timeoutMillis = timeoutMillis;
+        this.userAgent = userAgent;
+    }
+
+    public Document get(String url) {
+        try {
+            URI uri = URI.create(url);
+            InetAddress addr = InetAddress.getByName(uri.getHost());
+
+            if (isBlockedAddress(addr)) {
+                throw new SecurityException("SSRF 차단: 접근 불가 host=" + uri.getHost());
+            }
+
+            return Jsoup.connect(url)
+                .userAgent(userAgent)
+                .timeout(timeoutMillis)
+                .followRedirects(false) // 리다이렉트도 나중에 검증 후 허용
+                .get();
+
+        } catch (IOException e) {
+            throw new JsoupFetchException(url, e);
+        }
+    }
+
+    private boolean isBlockedAddress(InetAddress addr) {
+        // IPv4/IPv6 로컬 및 사설망
+        if (addr.isAnyLocalAddress() || addr.isLoopbackAddress() || addr.isSiteLocalAddress()) {
+            return true;
+        }
+
+        // AWS/GCP/Azure 메타데이터 서비스 (169.254.169.254)
+        String hostAddress = addr.getHostAddress();
+        if (hostAddress.equals("169.254.169.254")) {
+            return true;
+        }
+
+        // IPv6 link-local (fe80::/10)
+        if (addr.isLinkLocalAddress()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/sprint/ootd5team/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothes/controller/ClothesController.java
@@ -6,6 +6,7 @@ import com.sprint.ootd5team.domain.clothes.dto.request.ClothesUpdateRequest;
 import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDto;
 import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDtoCursorResponse;
 import com.sprint.ootd5team.domain.clothes.enums.ClothesType;
+import com.sprint.ootd5team.domain.clothes.extractor.ClothesExtractionService;
 import com.sprint.ootd5team.domain.clothes.service.ClothesService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ClothesController implements ClothesApi {
 
     private final ClothesService clothesService;
+    private final ClothesExtractionService clothesExtractionService;
 
     @Override
     public ResponseEntity<ClothesDtoCursorResponse> getClothes(
@@ -89,6 +91,14 @@ public class ClothesController implements ClothesApi {
 
     @Override
     public ResponseEntity<ClothesDto> extractByUrl(String url) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        log.info("[ClothesController] extractByUrl 요청 url={}", url);
+
+        ClothesDto clothesDto = clothesExtractionService.extractByUrl(url);
+
+        log.info("[ClothesController] 추출 결과 name={}, imageUrl={}",
+            clothesDto.name(), clothesDto.imageUrl());
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(clothesDto);
     }
 }

--- a/src/main/java/com/sprint/ootd5team/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothes/controller/ClothesController.java
@@ -89,9 +89,36 @@ public class ClothesController implements ClothesApi {
             .body(clothesDto);
     }
 
+    /**
+     * 의상 정보 추출 API.
+     *
+     * <p>외부 URL을 입력받아 해당 페이지에서 의상 정보를 크롤링한다.
+     * <br>요청 시 기본 검증:
+     * <ul>
+     *   <li>null/빈 문자열 차단</li>
+     *   <li>스킴은 http/https만 허용</li>
+     *   <li>잘못된 URI 형식은 400 Bad Request 응답</li>
+     * </ul>
+     *
+     * @param url 의상 페이지 URL
+     * @return 추출된 의상 정보 DTO (성공 시 200 OK, 잘못된 입력 시 400 Bad Request)
+     */
     @Override
     public ResponseEntity<ClothesDto> extractByUrl(String url) {
         log.info("[ClothesController] extractByUrl 요청 url={}", url);
+        if (url == null || url.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        try {
+            var u = java.net.URI.create(url);
+            String scheme = u.getScheme();
+            if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase(
+                "https"))) {
+                return ResponseEntity.badRequest().build();
+            }
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
 
         ClothesDto clothesDto = clothesExtractionService.extractByUrl(url);
 

--- a/src/main/java/com/sprint/ootd5team/domain/clothes/extractor/ClothesExtractionService.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothes/extractor/ClothesExtractionService.java
@@ -1,0 +1,8 @@
+package com.sprint.ootd5team.domain.clothes.extractor;
+
+import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDto;
+
+public interface ClothesExtractionService {
+
+    ClothesDto extractByUrl(String url);
+}

--- a/src/main/java/com/sprint/ootd5team/domain/clothes/extractor/WebScrapingClothesExtractionService.java
+++ b/src/main/java/com/sprint/ootd5team/domain/clothes/extractor/WebScrapingClothesExtractionService.java
@@ -1,0 +1,44 @@
+package com.sprint.ootd5team.domain.clothes.extractor;
+
+import com.sprint.ootd5team.base.jsoup.JsoupClient;
+import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Service;
+
+/**
+ * 웹 페이지(상품 상세 URL)를 크롤링 하여 의상 기본 정보를 추출하는 서비스
+ * - Jsoup 라이브러리를 통해 HTML 문서를 파싱
+ * - Open Graph(og) 메타 태그에서 상품 이름과 이미지를 가져옴
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WebScrapingClothesExtractionService implements ClothesExtractionService {
+
+    private final JsoupClient jsoupClient;
+
+    @Override
+    public ClothesDto extractByUrl(String url) {
+        try {
+            Document doc = jsoupClient.get(url);
+
+            String name = doc.title();
+            String imageUrl = doc.select("meta[property=og:image]").attr("content");
+
+            if (imageUrl == null || imageUrl.isBlank()) {
+                imageUrl = doc.select("img").first().absUrl("src");
+            }
+
+            return ClothesDto.builder()
+                .name(name != null ? name : "이름 없음")
+                .imageUrl(imageUrl)
+                .type(null)
+                .build();
+        } catch (Exception e) {
+            log.error("웹스크래핑 실패: {}", url, e);
+            throw new RuntimeException("옷 정보 추출 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,8 +21,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 20MB        # 업로드 허용 파일 크기
-      max-request-size: 20MB     # 요청 전체 크기
+      max-file-size: 50MB        # 스프링 전역 업로드 허용 파일 크기
+      max-request-size: 50MB     # 요청 전체 크기
 
 # SecurityConfig 비활성화/활성화 on off
 app:
@@ -78,4 +78,4 @@ ootd:
       region: ${AWS_REGION:ap-northeast-2}
       bucket: ${AWS_S3_BUCKET:zzootd-s3}
       presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600}
-      max-upload-size: 20MB
+      max-upload-size: 20MB   # 실제 정책상 허용할 크기

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,11 @@ spring:
       host: ${REDIS_HOST:redis}
       port: ${REDIS_PORT:6379}
 
+  servlet:
+    multipart:
+      max-file-size: 20MB        # 업로드 허용 파일 크기
+      max-request-size: 20MB     # 요청 전체 크기
+
 # SecurityConfig 비활성화/활성화 on off
 app:
   security:
@@ -73,4 +78,4 @@ ootd:
       region: ${AWS_REGION:ap-northeast-2}
       bucket: ${AWS_S3_BUCKET:zzootd-s3}
       presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600}
-      max-upload-size: 10MB
+      max-upload-size: 20MB

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -79,3 +79,7 @@ ootd:
       bucket: ${AWS_S3_BUCKET:zzootd-s3}
       presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600}
       max-upload-size: 20MB   # 실제 정책상 허용할 크기
+
+  jsoup:
+    timeout: 5000
+    user-agent: "OOTD-Extractor/1.0"

--- a/src/test/java/com/sprint/ootd5team/clothes/controller/ClothesControllerTest.java
+++ b/src/test/java/com/sprint/ootd5team/clothes/controller/ClothesControllerTest.java
@@ -16,9 +16,9 @@ import com.sprint.ootd5team.domain.clothes.dto.request.ClothesCreateRequest;
 import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDto;
 import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDtoCursorResponse;
 import com.sprint.ootd5team.domain.clothes.enums.ClothesType;
+import com.sprint.ootd5team.domain.clothes.extractor.ClothesExtractionService;
 import com.sprint.ootd5team.domain.clothes.service.ClothesService;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +47,9 @@ class ClothesControllerTest {
 
     @MockitoBean
     private ClothesService clothesService;
+
+    @MockitoBean
+    private ClothesExtractionService clothesExtractionService;
 
     private UUID ownerId;
     private List<ClothesDto> mockClothes;
@@ -173,19 +176,19 @@ class ClothesControllerTest {
         UUID attributeId = UUID.randomUUID();
 
         String requestJson = """
-        {
-          "name": "수정된 패딩",
-          "type": "OUTER",
-          "attributes": [
             {
-              "definitionId": "%s",
-              "definitionName": "계절",
-              "selectableValues": ["봄","여름","가을","겨울"],
-              "value": "봄"
+              "name": "수정된 패딩",
+              "type": "OUTER",
+              "attributes": [
+                {
+                  "definitionId": "%s",
+                  "definitionName": "계절",
+                  "selectableValues": ["봄","여름","가을","겨울"],
+                  "value": "봄"
+                }
+              ]
             }
-          ]
-        }
-        """.formatted(attributeId);
+            """.formatted(attributeId);
 
         MockMultipartFile requestPart = new MockMultipartFile(
             "request", "", "application/json", requestJson.getBytes(StandardCharsets.UTF_8)
@@ -201,7 +204,7 @@ class ClothesControllerTest {
             "clothes/uuid_new_coat.png",
             ClothesType.OUTER,
             List.of(new ClothesAttributeWithDefDto(
-                attributeId, "계절", List.of("봄","여름","가을","겨울"), "봄"
+                attributeId, "계절", List.of("봄", "여름", "가을", "겨울"), "봄"
             ))
         );
 
@@ -224,5 +227,26 @@ class ClothesControllerTest {
             .andExpect(jsonPath("$.attributes[0].value").value("봄"));
 
         verify(clothesService).update(eq(clothesId), any(), any(MultipartFile.class));
+    }
+
+    @Test
+    void 의상_url로_추출하면_이름과_이미지를_포함한_ClothesDto를_반환한다() throws Exception {
+        // given
+        String url = "https://dummy.com/product/1";
+        ClothesDto dto = ClothesDto.builder()
+            .name("테스트 상품")
+            .imageUrl("https://dummy.com/image.png")
+            .type(null)
+            .build();
+
+        given(clothesExtractionService.extractByUrl(url)).willReturn(dto);
+
+        // when & then
+        mockMvc.perform(get("/api/clothes/extractions")
+                .param("url", url))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.name").value("테스트 상품"))
+            .andExpect(jsonPath("$.imageUrl").value("https://dummy.com/image.png"))
+            .andExpect(jsonPath("$.type").doesNotExist());
     }
 }

--- a/src/test/java/com/sprint/ootd5team/clothes/controller/ClothesControllerTest.java
+++ b/src/test/java/com/sprint/ootd5team/clothes/controller/ClothesControllerTest.java
@@ -249,4 +249,19 @@ class ClothesControllerTest {
             .andExpect(jsonPath("$.imageUrl").value("https://dummy.com/image.png"))
             .andExpect(jsonPath("$.type").doesNotExist());
     }
+
+    @Test
+    void 잘못된_URL이면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/clothes/extractions")
+                .param("url", "ftp://malicious.com"))
+            .andExpect(status().isBadRequest());
+
+        mockMvc.perform(get("/api/clothes/extractions")
+                .param("url", ""))
+            .andExpect(status().isBadRequest());
+
+        mockMvc.perform(get("/api/clothes/extractions")
+                .param("url", "ht!tp://bad-url"))
+            .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/sprint/ootd5team/clothes/repository/ClothesRepositoryImplTest.java
+++ b/src/test/java/com/sprint/ootd5team/clothes/repository/ClothesRepositoryImplTest.java
@@ -106,7 +106,7 @@ class ClothesRepositoryImplTest {
     void createdAtCursor가_같으면_id값을_기준_다음페이지조회() {
         // given
         Instant cursor = Instant.parse("2024-01-01T08:00:00Z");
-        UUID idAfter = clothes.getId();
+        UUID idAfter = clothes.getId(); // "운동화2"
 
         // when
         List<Clothes> result = clothesRepository.findClothes(
@@ -117,9 +117,7 @@ class ClothesRepositoryImplTest {
             10
         );
 
-        assertThat(result)
-            .extracting(Clothes::getName)
-            .containsAnyOf("운동화", "운동화2");
+        // then
         assertThat(result.get(0).getCreatedAt()).isEqualTo(cursor);
     }
 }

--- a/src/test/java/com/sprint/ootd5team/clothes/repository/ClothesRepositoryImplTest.java
+++ b/src/test/java/com/sprint/ootd5team/clothes/repository/ClothesRepositoryImplTest.java
@@ -6,13 +6,10 @@ import com.sprint.ootd5team.base.config.QuerydslConfig;
 import com.sprint.ootd5team.domain.clothes.entity.Clothes;
 import com.sprint.ootd5team.domain.clothes.enums.ClothesType;
 import com.sprint.ootd5team.domain.clothes.repository.ClothesRepositoryImpl;
-import com.sprint.ootd5team.domain.user.entity.Role;
-import com.sprint.ootd5team.domain.user.entity.User;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,53 +17,21 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @Import(QuerydslConfig.class)
 @TestPropertySource(properties = "spring.sql.init.mode=never")
+@Sql(scripts = "classpath:clothesData.sql")
 @ActiveProfiles("test")
 @DisplayName("ClothesRepositoryImpl 테스트")
 class ClothesRepositoryImplTest {
 
+    private static final UUID ownerId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     @Autowired
     private ClothesRepositoryImpl clothesRepository;
-
     @Autowired
     private EntityManager em;
-
-    private User owner;
-    private UUID ownerId;
-    private Clothes clothes;
-
-    @BeforeEach
-    void setUp() {
-        owner = new User("쪼쪼", "zzo@email.com", "zzo1234!", Role.USER);
-        ReflectionTestUtils.setField(owner, "createdAt", Instant.parse("2024-01-01T00:00:00Z"));
-        em.persist(owner);
-        em.flush();
-        ownerId = owner.getId();
-
-        em.persist(makeClothes(owner, "흰 티셔츠", ClothesType.TOP, "2024-01-01T10:00:00Z"));
-        em.persist(makeClothes(owner, "청바지", ClothesType.BOTTOM, "2024-01-01T09:00:00Z"));
-        em.persist(makeClothes(owner, "운동화", ClothesType.SHOES, "2024-01-01T08:00:00Z"));
-
-        clothes = makeClothes(owner, "운동화2", ClothesType.SHOES, "2024-01-01T08:00:00Z");
-        em.persist(clothes);
-        em.flush();
-        em.clear();
-    }
-
-    private Clothes makeClothes(User owner, String name, ClothesType type, String createdAt) {
-        Clothes clothes = Clothes.builder()
-            .owner(owner)
-            .name(name)
-            .type(type)
-            .imageUrl(null)
-            .build();
-        ReflectionTestUtils.setField(clothes, "createdAt", Instant.parse(createdAt));
-        return clothes;
-    }
 
     @Test
     void TOP타입에_해당하는_결과_반환() {
@@ -99,18 +64,18 @@ class ClothesRepositoryImplTest {
         assertThat(result)
             .isNotEmpty()
             .extracting(Clothes::getName)
-            .contains("운동화", "운동화2");
+            .containsExactlyInAnyOrder("운동화1", "운동화2", "운동화3");
     }
 
     @Test
-    void createdAtCursor가_같으면_id값을_기준_다음페이지조회() {
+    void createdAtCursor가_같으면_id값을_기준으로_다음페이지를_조회한다() {
         // given
         Instant cursor = Instant.parse("2024-01-01T08:00:00Z");
-        UUID idAfter = clothes.getId(); // "운동화2"
+        UUID idAfter = UUID.fromString("22222222-2222-2222-2222-222222222222"); // 운동화2
 
         // when
         List<Clothes> result = clothesRepository.findClothes(
-            ownerId,
+            UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
             null,
             cursor,
             idAfter,
@@ -118,6 +83,7 @@ class ClothesRepositoryImplTest {
         );
 
         // then
-        assertThat(result.get(0).getCreatedAt()).isEqualTo(cursor);
+        assertThat(result).extracting(Clothes::getId)
+            .containsExactly(UUID.fromString("11111111-1111-1111-1111-111111111111")); // 운동화1
     }
 }

--- a/src/test/java/com/sprint/ootd5team/clothes/service/WebScrapingClothesExtractionServiceTest.java
+++ b/src/test/java/com/sprint/ootd5team/clothes/service/WebScrapingClothesExtractionServiceTest.java
@@ -5,8 +5,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDto;
+import com.sprint.ootd5team.base.exception.clothes.ClothesExtractionFailedException;
 import com.sprint.ootd5team.base.jsoup.JsoupClient;
+import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDto;
 import com.sprint.ootd5team.domain.clothes.extractor.WebScrapingClothesExtractionService;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -35,7 +36,7 @@ public class WebScrapingClothesExtractionServiceTest {
     }
 
     @Test
-    void og_메타태그로_기본_조회한다() throws Exception {
+    void og_메타태그로_기본_조회한다() {
         // given
         String url = "https://dummy.com/product/1";
         String html = """
@@ -59,7 +60,7 @@ public class WebScrapingClothesExtractionServiceTest {
     }
 
     @Test
-    void og_메타태그가_없으면_src로_조회한다() throws Exception {
+    void og_메타태그가_없으면_src로_조회한다() {
         // given
         String url = "https://dummy.com/product/2";
         String html = """
@@ -85,7 +86,7 @@ public class WebScrapingClothesExtractionServiceTest {
     }
 
     @Test
-    void JsoupClient에서_예외가_발생하면_RuntimeException을_던진다() throws Exception {
+    void JsoupClient에서_예외가_발생하면_RuntimeException을_던진다() {
         // given
         String url = "https://dummy.com/product/3";
         given(jsoupClient.get(url)).willThrow(new RuntimeException("연결 실패"));
@@ -94,7 +95,63 @@ public class WebScrapingClothesExtractionServiceTest {
         Throwable thrown = catchThrowable(() -> service.extractByUrl(url));
 
         // then
-        assertThat(thrown).isInstanceOf(RuntimeException.class)
-            .hasMessageContaining("옷 정보 추출 실패");
+        assertThat(thrown).isInstanceOf(ClothesExtractionFailedException.class);
+    }
+
+    @Test
+    void og_title이_title보다_우선한다() {
+        String url = "https://dummy.com/product/4";
+        String html = """
+            <html>
+              <head>
+                <title>타이틀 이름</title>
+                <meta property="og:title" content="OG 타이틀"/>
+                <meta property="og:image" content="https://dummy.com/og.png"/>
+              </head>
+            </html>
+            """;
+        Document doc = Jsoup.parse(html, url);
+        given(jsoupClient.get(url)).willReturn(doc);
+
+        ClothesDto result = service.extractByUrl(url);
+
+        assertThat(result.name()).isEqualTo("OG 타이틀");
+    }
+
+    @Test
+    void title이_비어있으면_기본값을_반환한다() {
+        String url = "https://dummy.com/product/5";
+        String html = """
+            <html>
+              <head></head>
+              <body></body>
+            </html>
+            """;
+        Document doc = Jsoup.parse(html, url);
+        given(jsoupClient.get(url)).willReturn(doc);
+
+        ClothesDto result = service.extractByUrl(url);
+
+        assertThat(result.name()).isEqualTo("이름 없음");
+        assertThat(result.imageUrl()).isNull();
+    }
+
+    @Test
+    void og_image가_상대경로이면_절대경로로_변환한다() {
+        String url = "https://dummy.com/product/6";
+        String html = """
+            <html>
+              <head>
+                <meta property="og:title" content="상대경로 상품"/>
+                <meta property="og:image" content="/img/foo.png"/>
+              </head>
+            </html>
+            """;
+        Document doc = Jsoup.parse(html, url);
+        given(jsoupClient.get(url)).willReturn(doc);
+
+        ClothesDto result = service.extractByUrl(url);
+
+        assertThat(result.imageUrl()).isEqualTo("https://dummy.com/img/foo.png");
     }
 }

--- a/src/test/java/com/sprint/ootd5team/clothes/service/WebScrapingClothesExtractionServiceTest.java
+++ b/src/test/java/com/sprint/ootd5team/clothes/service/WebScrapingClothesExtractionServiceTest.java
@@ -1,0 +1,100 @@
+package com.sprint.ootd5team.clothes.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.sprint.ootd5team.domain.clothes.dto.response.ClothesDto;
+import com.sprint.ootd5team.base.jsoup.JsoupClient;
+import com.sprint.ootd5team.domain.clothes.extractor.WebScrapingClothesExtractionService;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WebScrapingService 단위 테스트")
+public class WebScrapingClothesExtractionServiceTest {
+
+    @Mock
+    private JsoupClient jsoupClient;
+
+    @InjectMocks
+    private WebScrapingClothesExtractionService service;
+
+    @BeforeEach
+    void setUp() {
+        jsoupClient = mock(JsoupClient.class);
+        service = new WebScrapingClothesExtractionService(jsoupClient);
+    }
+
+    @Test
+    void og_메타태그로_기본_조회한다() throws Exception {
+        // given
+        String url = "https://dummy.com/product/1";
+        String html = """
+            <html>
+              <head>
+                <title>테스트 상품</title>
+                <meta property="og:image" content="https://dummy.com/og.png"/>
+              </head>
+            </html>
+            """;
+        Document doc = Jsoup.parse(html, url);
+
+        given(jsoupClient.get(url)).willReturn(doc);
+
+        // when
+        ClothesDto result = service.extractByUrl(url);
+
+        // then
+        assertThat(result.name()).isEqualTo("테스트 상품");
+        assertThat(result.imageUrl()).isEqualTo("https://dummy.com/og.png");
+    }
+
+    @Test
+    void og_메타태그가_없으면_src로_조회한다() throws Exception {
+        // given
+        String url = "https://dummy.com/product/2";
+        String html = """
+            <html>
+              <head>
+                <title>이미지 없는 상품</title>
+              </head>
+              <body>
+                <img src="https://dummy.com/fallback.png"/>
+              </body>
+            </html>
+            """;
+        Document doc = Jsoup.parse(html, url);
+
+        given(jsoupClient.get(url)).willReturn(doc);
+
+        // when
+        ClothesDto result = service.extractByUrl(url);
+
+        // then
+        assertThat(result.name()).isEqualTo("이미지 없는 상품");
+        assertThat(result.imageUrl()).isEqualTo("https://dummy.com/fallback.png");
+    }
+
+    @Test
+    void JsoupClient에서_예외가_발생하면_RuntimeException을_던진다() throws Exception {
+        // given
+        String url = "https://dummy.com/product/3";
+        given(jsoupClient.get(url)).willThrow(new RuntimeException("연결 실패"));
+
+        // when
+        Throwable thrown = catchThrowable(() -> service.extractByUrl(url));
+
+        // then
+        assertThat(thrown).isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("옷 정보 추출 실패");
+    }
+}

--- a/src/test/java/com/sprint/ootd5team/storage/S3FileStorageTest.java
+++ b/src/test/java/com/sprint/ootd5team/storage/S3FileStorageTest.java
@@ -183,7 +183,8 @@ class S3FileStorageTest {
     @Test
     void 업로드_실패_용량초과() {
         // given
-        S3FileStorage smallLimitStorage = new S3FileStorage(s3Client, s3Presigner, DataSize.ofBytes(1));
+        S3FileStorage smallLimitStorage = new S3FileStorage(s3Client, s3Presigner,
+            DataSize.ofBytes(1));
         ReflectionTestUtils.setField(smallLimitStorage, "bucket", "test-bucket");
 
         InputStream inputStream = new ByteArrayInputStream("hello".getBytes());
@@ -211,10 +212,18 @@ class S3FileStorageTest {
     }
 
     @Test
-    void recover_항상_FilePermanentSaveFailedException발생() {
-        // when & then
-        assertThatThrownBy(() ->
-            s3FileStorage.recover(new RuntimeException("fail"), "bad.png", null, "image/png")
-        ).isInstanceOf(FilePermanentSaveFailedException.class);
+    void 업로드시_png확장자이면_imagePng으로설정된다() {
+        // given
+        InputStream inputStream = new ByteArrayInputStream("data".getBytes());
+
+        // when
+        s3FileStorage.upload("test.png", inputStream, "application/octet-stream");
+
+        // then
+        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(captor.capture(), any(RequestBody.class));
+
+        assertThat(captor.getValue().contentType()).isEqualTo("image/png");
     }
+
 }

--- a/src/test/resources/clothesData.sql
+++ b/src/test/resources/clothesData.sql
@@ -1,0 +1,32 @@
+-- User 삽입
+INSERT INTO tbl_users
+(id, name, email, password, role, is_locked, created_at, updated_at, temp_password,
+ temp_password_expired_at)
+VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        '쪼쪼',
+        'zzo@email.com',
+        'zzo1234!',
+        'USER',
+        FALSE,
+        '2024-01-01 00:00:00+00',
+        NOW(),
+        NULL,
+        NULL);
+
+
+-- Clothes 데이터 삽입
+INSERT INTO tbl_clothes (id, owner_id, name, type, image_url, created_at, updated_at)
+VALUES ('aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        '흰 티셔츠', 'TOP', null, '2024-01-01 10:00:00+00', NOW()),
+
+       ('bbbbbbbb-0000-0000-0000-aaaaaaaaaaaa', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        '청바지', 'BOTTOM', null, '2024-01-01 09:00:00+00', NOW()),
+
+       ('11111111-1111-1111-1111-111111111111', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        '운동화1', 'SHOES', null, '2024-01-01 08:00:00+00', NOW()),
+
+       ('22222222-2222-2222-2222-222222222222', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        '운동화2', 'SHOES', null, '2024-01-01 08:00:00+00', NOW()),
+
+       ('33333333-3333-3333-3333-333333333333', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        '운동화3', 'SHOES', null, '2024-01-01 08:00:00+00', NOW());


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->
CODEITSB03-24

## 📝 요약(Summary)
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
 - url입력시 웹 페이지의 메타데이터(og:title, og:image)를 크롤링하여 자동으로 이름과 이미지를 가져옴

## 🛠️ PR 변경 사항
<!-- 어떤 변경 사항이 있나요? -->
- ClothesExtractionService 인터페이스 정의
- WebScrapingClothesExtractionService 구현체 추가 (Jsoup 기반)
- og:image → 이미지 URL 추출
- title 태그 → 의상 이름 추출
- fallback: og:image가 없을 경우 첫 번째 <img> 태그 사용

## 📸스크린샷 (선택)
<!-- 관련 스크린샷을 첨부해 주세요 -->
<img width="590" height="919" alt="스크린샷 2025-09-22 022359" src="https://github.com/user-attachments/assets/f4e7b134-f55d-45ed-bfba-cc38db0a8123" />
<img width="1765" height="909" alt="스크린샷 2025-09-22 024538" src="https://github.com/user-attachments/assets/e55ba825-4e89-4ffb-afd5-040e404661b9" />

## 💬 공유사항
<!-- 논의해야할 부분이 있다면 적어주세요.-->
- 현재는 의상 이름과 이미지만 추출
- html 구조가 url별로 다르기 때문에 일부 사이트에서는 의도대로 추출되지 않을 수 있음
- 크롤링 대신 api 연동으로 확장도 고려

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x]  기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [x]  예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
<img width="765" height="653" alt="스크린샷 2025-09-22 030002" src="https://github.com/user-attachments/assets/87b875df-50ae-4d54-9215-2974017d3ed6" />

- [x]  테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [x]  실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 웹 페이지 URL로 옷 정보를 추출해 이름·이미지를 반환하는 기능을 추가했습니다.

- Bug Fixes
  - 업로드 시 파일 확장자 기반 콘텐츠 타입 판정 강화로 잘못된 MIME 적용을 개선했습니다.
  - 대용량 업로드 예외 처리 개선으로 파일 크기 초과 상황 응답을 명확히 했습니다.
  - 웹 스크래핑/추출 실패에 대한 명확한 오류 응답을 추가했습니다.

- Chores
  - HTML 파싱 라이브러리 및 관련 설정(타임아웃, User-Agent) 추가 및 업로드 용량 상향(앱 50MB, S3 20MB).

- Tests
  - 웹 스크래핑 추출 및 컨트롤러 관련 단위/통합 테스트 추가·갱신.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->