### PR TITLE
feat: 피드 댓글 등록 기능 구현 및 테스트

### DIFF
--- a/src/main/java/com/sprint/ootd5team/domain/comment/controller/FeedCommentController.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/controller/FeedCommentController.java
@@ -41,9 +41,13 @@ public class FeedCommentController implements FeedCommentApi {
             .body(response);
     }
 
+    @Override
     @PostMapping("/{feedId}/comments")
-    public ResponseEntity<CommentDto> create(@Valid @RequestBody CommentCreateRequest commentCreateRequest) {
-        CommentDto commentDto = feedCommentService.create(commentCreateRequest);
+    public ResponseEntity<CommentDto> create(
+        @PathVariable UUID feedId,
+        @Valid @RequestBody CommentCreateRequest commentCreateRequest
+    ) {
+        CommentDto commentDto = feedCommentService.create(feedId, commentCreateRequest);
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/src/main/java/com/sprint/ootd5team/domain/comment/controller/FeedCommentController.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/controller/FeedCommentController.java
@@ -41,6 +41,7 @@ public class FeedCommentController implements FeedCommentApi {
             .body(response);
     }
 
+    //ToDo: 추후에 AuthorId를 Dto가 아닌 AuthService에서 받아오도록 수정할 수 있음.
     @Override
     @PostMapping("/{feedId}/comments")
     public ResponseEntity<CommentDto> create(

--- a/src/main/java/com/sprint/ootd5team/domain/comment/controller/api/FeedCommentApi.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/controller/api/FeedCommentApi.java
@@ -36,7 +36,7 @@ public interface FeedCommentApi {
     @Operation(summary = "피드 댓글 등록")
     @ApiResponses(value = {
         @ApiResponse(
-            responseCode = "200", description = "피드 댓글 등록 성공",
+            responseCode = "201", description = "피드 댓글 등록 성공",
             content = @Content(schema = @Schema(implementation = CommentDto.class))
         ),
         @ApiResponse(

--- a/src/main/java/com/sprint/ootd5team/domain/comment/controller/api/FeedCommentApi.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/controller/api/FeedCommentApi.java
@@ -29,10 +29,23 @@ public interface FeedCommentApi {
         )
     })
     ResponseEntity<CommentDtoCursorResponse> getComments(
-        @Parameter(description = "feedId", required = true)
-        UUID feedId,
-        @ParameterObject
-        CommentListRequest commentListRequest
+        @Parameter(description = "feedId", required = true) UUID feedId,
+        @ParameterObject CommentListRequest commentListRequest
     );
-    ResponseEntity<CommentDto> create(CommentCreateRequest commentCreateRequest);
+
+    @Operation(summary = "피드 댓글 등록")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200", description = "피드 댓글 등록 성공",
+            content = @Content(schema = @Schema(implementation = CommentDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "400", description = "피드 댓글 등록 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<CommentDto> create(
+        @Parameter(description = "feedId", required = true) UUID feedId,
+        CommentCreateRequest commentCreateRequest
+    );
 }

--- a/src/main/java/com/sprint/ootd5team/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/dto/request/CommentCreateRequest.java
@@ -3,7 +3,6 @@ package com.sprint.ootd5team.domain.comment.dto.request;
 import java.util.UUID;
 
 public record CommentCreateRequest(
-    UUID feedId,
     UUID authorId,
     String content
 ) { }

--- a/src/main/java/com/sprint/ootd5team/domain/comment/mapper/FeedCommentMapper.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/mapper/FeedCommentMapper.java
@@ -1,0 +1,19 @@
+package com.sprint.ootd5team.domain.comment.mapper;
+
+import com.sprint.ootd5team.domain.comment.dto.data.CommentDto;
+import com.sprint.ootd5team.domain.comment.entity.FeedComment;
+import com.sprint.ootd5team.domain.profile.entity.Profile;
+import com.sprint.ootd5team.domain.profile.mapper.ProfileMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {ProfileMapper.class})
+public interface FeedCommentMapper  {
+
+    @Mapping(source = "comment.id", target = "id")
+    @Mapping(source = "comment.createdAt", target = "createdAt")
+    @Mapping(source = "comment.feedId", target = "feedId")
+    @Mapping(source = "profile", target = "author")
+    @Mapping(source = "comment.content", target = "content")
+    CommentDto toDto(FeedComment comment, Profile profile);
+}

--- a/src/main/java/com/sprint/ootd5team/domain/comment/service/FeedCommentService.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/service/FeedCommentService.java
@@ -10,5 +10,5 @@ public interface FeedCommentService {
 
     CommentDtoCursorResponse getComments(UUID feedId, CommentListRequest request);
 
-    CommentDto create(CommentCreateRequest commentCreateRequest);
+    CommentDto create(UUID feedId, CommentCreateRequest commentCreateRequest);
 }

--- a/src/main/java/com/sprint/ootd5team/domain/comment/service/FeedCommentServiceImpl.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/service/FeedCommentServiceImpl.java
@@ -88,7 +88,7 @@ public class FeedCommentServiceImpl implements FeedCommentService {
         UUID authorId = commentCreateRequest.authorId();
 
         log.info("[FeedCommentService] 댓글 등록 요청 시작 - "
-            + "feedId={}, authorId={}, content={}", feedId, authorId, commentCreateRequest.content());
+            + "feedId={}, content={}", feedId, commentCreateRequest.content());
 
         validateFeed(feedId);
 
@@ -97,7 +97,7 @@ public class FeedCommentServiceImpl implements FeedCommentService {
 
         FeedComment feedComment = new FeedComment(feedId, authorId, commentCreateRequest.content());
         FeedComment saved = feedCommentRepository.save(feedComment);
-        log.debug("[FeedCommentServie] 저장된 FeedComment: {}", saved);
+        log.debug("[FeedCommentService] 저장된 FeedComment: {}", saved);
 
         feedRepository.incrementCommentCount(feedId);
 

--- a/src/main/java/com/sprint/ootd5team/domain/comment/service/FeedCommentServiceImpl.java
+++ b/src/main/java/com/sprint/ootd5team/domain/comment/service/FeedCommentServiceImpl.java
@@ -1,12 +1,17 @@
 package com.sprint.ootd5team.domain.comment.service;
 
 import com.sprint.ootd5team.base.exception.feed.FeedNotFoundException;
+import com.sprint.ootd5team.base.exception.profile.ProfileNotFoundException;
 import com.sprint.ootd5team.domain.comment.dto.data.CommentDto;
 import com.sprint.ootd5team.domain.comment.dto.request.CommentCreateRequest;
 import com.sprint.ootd5team.domain.comment.dto.request.CommentListRequest;
 import com.sprint.ootd5team.domain.comment.dto.response.CommentDtoCursorResponse;
+import com.sprint.ootd5team.domain.comment.entity.FeedComment;
+import com.sprint.ootd5team.domain.comment.mapper.FeedCommentMapper;
 import com.sprint.ootd5team.domain.comment.repository.FeedCommentRepository;
 import com.sprint.ootd5team.domain.feed.repository.feed.FeedRepository;
+import com.sprint.ootd5team.domain.profile.entity.Profile;
+import com.sprint.ootd5team.domain.profile.repository.ProfileRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -23,14 +28,22 @@ public class FeedCommentServiceImpl implements FeedCommentService {
 
     private final FeedCommentRepository feedCommentRepository;
     private final FeedRepository feedRepository;
+    private final ProfileRepository profileRepository;
+    private final FeedCommentMapper feedCommentMapper;
 
+    /**
+     * 피드에 달린 댓글 목록을 커서 기반 페이지네이션으로 조회한다.
+     *
+     * @param feedId  조회할 피드 ID
+     * @param request 커서, limit 등 페이지네이션 요청 파라미터
+     * @return 댓글 목록과 커서 정보를 담은 응답 DTO
+     * @throws FeedNotFoundException 피드가 존재하지 않을 경우
+     */
+    @Override
     public CommentDtoCursorResponse getComments(UUID feedId, CommentListRequest request) {
         log.info("[FeedCommentService] 댓글 목록 조회 요청 시작 - feedId={}", feedId);
 
-        if (!feedRepository.existsById(feedId)) {
-            log.warn("조회되지 않는 피드입니다. feedId={}", feedId);
-            throw FeedNotFoundException.withId(feedId);
-        }
+        validateFeed(feedId);
 
         Instant createdAtCursor = request.cursor() != null ? Instant.parse(request.cursor()) : null;
         UUID idCursor = request.idAfter();
@@ -60,10 +73,41 @@ public class FeedCommentServiceImpl implements FeedCommentService {
         );
     }
 
-    //Todo
-    public CommentDto create(CommentCreateRequest commentCreateRequest) {
-        CommentDto commentDto = null;
+    /**
+     * 새로운 댓글을 생성한다.
+     *
+     * @param feedId              댓글이 달릴 피드 ID
+     * @param commentCreateRequest 댓글 생성 요청 (작성자 ID, 내용 포함)
+     * @return 저장된 댓글 DTO
+     * @throws FeedNotFoundException    피드가 존재하지 않을 경우
+     * @throws ProfileNotFoundException 작성자 프로필이 없을 경우
+     */
+    @Override
+    @Transactional
+    public CommentDto create(UUID feedId, CommentCreateRequest commentCreateRequest) {
+        UUID authorId = commentCreateRequest.authorId();
 
-        return commentDto;
+        log.info("[FeedCommentService] 댓글 등록 요청 시작 - "
+            + "feedId={}, authorId={}, content={}", feedId, authorId, commentCreateRequest.content());
+
+        validateFeed(feedId);
+
+        Profile profile = profileRepository.findByUserId(authorId)
+            .orElseThrow(() -> ProfileNotFoundException.withUserId(authorId));
+
+        FeedComment feedComment = new FeedComment(feedId, authorId, commentCreateRequest.content());
+        FeedComment saved = feedCommentRepository.save(feedComment);
+        log.debug("[FeedCommentServie] 저장된 FeedComment: {}", saved);
+
+        feedRepository.incrementCommentCount(feedId);
+
+        return feedCommentMapper.toDto(saved, profile);
+    }
+
+    private void validateFeed(UUID feedId) {
+        if (!feedRepository.existsById(feedId)) {
+            log.warn("[FeedCommentService] 유효하지 않은 피드 - feedId:{}", feedId);
+            throw FeedNotFoundException.withId(feedId);
+        }
     }
 }

--- a/src/main/java/com/sprint/ootd5team/domain/feed/entity/Feed.java
+++ b/src/main/java/com/sprint/ootd5team/domain/feed/entity/Feed.java
@@ -48,12 +48,4 @@ public class Feed extends BaseUpdatableEntity {
     public void updateContent(String content) {
         this.content = content;
     }
-
-    public void like() {
-        this.likeCount++;
-    }
-
-    public void unLike() {
-        this.likeCount--;
-    }
 }

--- a/src/main/java/com/sprint/ootd5team/domain/feed/repository/feed/FeedRepository.java
+++ b/src/main/java/com/sprint/ootd5team/domain/feed/repository/feed/FeedRepository.java
@@ -16,4 +16,8 @@ public interface FeedRepository extends JpaRepository<Feed, UUID>, FeedRepositor
     @Modifying
     @Query("update Feed f set f.likeCount = f.likeCount - 1 where f.id = :feedId and f.likeCount > 0")
     int decrementLikeCount(@Param("feedId") UUID feedId);
+
+    @Modifying
+    @Query("update Feed f set f.commentCount = f.commentCount + 1 where f.id = :feedId")
+    void incrementCommentCount(@Param("feedId") UUID feedId);
 }

--- a/src/main/java/com/sprint/ootd5team/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/sprint/ootd5team/domain/profile/mapper/ProfileMapper.java
@@ -3,6 +3,7 @@ package com.sprint.ootd5team.domain.profile.mapper;
 import com.sprint.ootd5team.domain.location.mapper.LocationMapper;
 import com.sprint.ootd5team.domain.profile.dto.request.ProfileDto;
 import com.sprint.ootd5team.domain.profile.entity.Profile;
+import com.sprint.ootd5team.domain.user.dto.AuthorDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -13,4 +14,6 @@ public abstract class ProfileMapper {
 
     @Mapping(target = "location", source = ".", qualifiedByName = "profileToLocationDto")
     public abstract ProfileDto toDto(Profile profile);
+
+    public abstract AuthorDto toAuthorDto(Profile profile);
 }

--- a/src/test/java/com/sprint/ootd5team/comment/mapper/FeedCommentMapperTest.java
+++ b/src/test/java/com/sprint/ootd5team/comment/mapper/FeedCommentMapperTest.java
@@ -1,0 +1,51 @@
+package com.sprint.ootd5team.comment.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sprint.ootd5team.domain.comment.dto.data.CommentDto;
+import com.sprint.ootd5team.domain.comment.entity.FeedComment;
+import com.sprint.ootd5team.domain.comment.mapper.FeedCommentMapper;
+import com.sprint.ootd5team.domain.comment.mapper.FeedCommentMapperImpl;
+import com.sprint.ootd5team.domain.profile.entity.Profile;
+import com.sprint.ootd5team.domain.profile.mapper.ProfileMapper;
+import com.sprint.ootd5team.domain.profile.mapper.ProfileMapperImpl;
+import java.lang.reflect.Field;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("FeedCommentMapper 단위 테스트")
+class FeedCommentMapperTest {
+
+    private final FeedCommentMapper mapper;
+
+    FeedCommentMapperTest() throws Exception {
+        FeedCommentMapperImpl impl = new FeedCommentMapperImpl();
+
+        ProfileMapper profileMapper = new ProfileMapperImpl();
+        Field field = FeedCommentMapperImpl.class.getDeclaredField("profileMapper");
+        field.setAccessible(true);
+        field.set(impl, profileMapper);
+
+        this.mapper = impl;
+    }
+
+    @Test
+    void toDto_success() {
+        UUID feedId = UUID.randomUUID();
+        UUID authorId = UUID.randomUUID();
+
+        FeedComment comment = new FeedComment(feedId, authorId, "테스트 댓글");
+
+        Profile profile = new Profile();
+        ReflectionTestUtils.setField(profile, "userId", authorId);
+        ReflectionTestUtils.setField(profile, "name", "테스터");
+
+        CommentDto dto = mapper.toDto(comment, profile);
+
+        assertThat(dto.feedId()).isEqualTo(feedId);
+        assertThat(dto.content()).isEqualTo("테스트 댓글");
+        assertThat(dto.author().userId()).isEqualTo(authorId);
+    }
+}

--- a/src/test/java/com/sprint/ootd5team/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/sprint/ootd5team/feed/controller/FeedControllerTest.java
@@ -240,4 +240,39 @@ public class FeedControllerTest {
         then(feedService).should().create(any(FeedCreateRequest.class), eq(userId));
         then(authService).should().getCurrentUserId();
     }
+
+    @Test
+    @DisplayName("Feed 단건 조회 성공")
+    void getFeed_success() throws Exception {
+        // given
+        UUID feedId = UUID.randomUUID();
+        UUID currentUserId = UUID.randomUUID();
+
+        FeedDto mockDto = new FeedDto(
+            feedId,
+            Instant.now(),
+            Instant.now(),
+            new AuthorDto(currentUserId, "작성자", "profile.jpg"),
+            new WeatherSummaryDto(
+                UUID.randomUUID(),
+                SkyStatus.CLEAR,
+                new PrecipitationDto(PrecipitationType.NONE, 0.0, 0.0),
+                new TemperatureDto(20.0, 0.0, 18.0, 25.0)
+            ),
+            List.of(), // ootds
+            "테스트 피드",
+            3, 1, false
+        );
+
+        given(feedService.getFeed(feedId, currentUserId)).willReturn(mockDto);
+
+        // when & then
+        mockMvc.perform(get("/api/feeds/{feedId}", feedId)
+                .param("currentUserId", currentUserId.toString())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(feedId.toString()))
+            .andExpect(jsonPath("$.author.userId").value(currentUserId.toString()))
+            .andExpect(jsonPath("$.content").value("테스트 피드"));
+    }
 }

--- a/src/test/java/com/sprint/ootd5team/feed/enums/SortDirectionTest.java
+++ b/src/test/java/com/sprint/ootd5team/feed/enums/SortDirectionTest.java
@@ -1,0 +1,26 @@
+package com.sprint.ootd5team.feed.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sprint.ootd5team.domain.feed.dto.enums.SortDirection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+@DisplayName("SortDirection toSpringDirection 테스트")
+class SortDirectionTest {
+
+    @Test
+    @DisplayName("ASCENDING은 Sort.Direction.ASC로 매핑된다")
+    void ascendingToSpringDirection() {
+        assertThat(SortDirection.ASCENDING.toSpringDirection())
+            .isEqualTo(Sort.Direction.ASC);
+    }
+
+    @Test
+    @DisplayName("DESCENDING은 Sort.Direction.DESC로 매핑된다")
+    void descendingToSpringDirection() {
+        assertThat(SortDirection.DESCENDING.toSpringDirection())
+            .isEqualTo(Sort.Direction.DESC);
+    }
+}

--- a/src/test/java/com/sprint/ootd5team/feed/repository/FeedRepositoryImplTest.java
+++ b/src/test/java/com/sprint/ootd5team/feed/repository/FeedRepositoryImplTest.java
@@ -1,9 +1,11 @@
 package com.sprint.ootd5team.feed.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sprint.ootd5team.base.config.JpaAuditingConfig;
 import com.sprint.ootd5team.base.config.QuerydslConfig;
+import com.sprint.ootd5team.base.exception.feed.InvalidSortOptionException;
 import com.sprint.ootd5team.domain.clothattribute.entity.ClothesAttribute;
 import com.sprint.ootd5team.domain.clothattribute.entity.ClothesAttributeDef;
 import com.sprint.ootd5team.domain.clothattribute.entity.ClothesAttributeValue;
@@ -11,6 +13,8 @@ import com.sprint.ootd5team.domain.clothes.entity.Clothes;
 import com.sprint.ootd5team.domain.clothes.enums.ClothesType;
 import com.sprint.ootd5team.domain.feed.dto.data.FeedDto;
 import com.sprint.ootd5team.domain.feed.dto.data.OotdDto;
+import com.sprint.ootd5team.domain.feed.dto.enums.SortDirection;
+import com.sprint.ootd5team.domain.feed.dto.request.FeedListRequest;
 import com.sprint.ootd5team.domain.feed.entity.Feed;
 import com.sprint.ootd5team.domain.feed.entity.FeedClothes;
 import com.sprint.ootd5team.domain.feed.repository.feed.FeedRepository;
@@ -57,13 +61,7 @@ public class FeedRepositoryImplTest {
     void setUp() {
         feedId = UUID.randomUUID();
 
-        User owner = new User(
-            "테스트유저",
-            "test@example.com",
-            "password",
-            Role.USER
-        );
-        em.persist(owner);
+        User owner = createUser("테스트유저", "test@example.com");
 
         Clothes clothes = Clothes.builder()
             .name("아디다스 트레이닝 팬츠")
@@ -73,17 +71,12 @@ public class FeedRepositoryImplTest {
             .build();
         em.persist(clothes);
 
-        FeedClothes feedClothes = new FeedClothes(feedId, clothes.getId());
-        em.persist(feedClothes);
+        em.persist(new FeedClothes(feedId, clothes.getId()));
 
         ClothesAttribute attr = new ClothesAttribute("색상");
         em.persist(attr);
-
-        ClothesAttributeDef attrDef = new ClothesAttributeDef(attr, "초록");
-        em.persist(attrDef);
-
-        ClothesAttributeValue cav = new ClothesAttributeValue(clothes, attr, "초록");
-        em.persist(cav);
+        em.persist(new ClothesAttributeDef(attr, "초록"));
+        em.persist(new ClothesAttributeValue(clothes, attr, "초록"));
 
         em.flush();
         em.clear();
@@ -124,42 +117,15 @@ public class FeedRepositoryImplTest {
     @DisplayName("FeedId와 UserId로 FeedDto 단건 조회 성공")
     void findFeedDtoById_success() {
         // given
-        User user = new User("작성자", "author@example.com", "password", Role.USER);
-        em.persist(user);
+        User user = createUser("작성자", "author@example.com");
+        Profile profile = createProfile(user);
+        Weather weather = createWeather(profile, SkyStatus.CLEAR, PrecipitationType.NONE);
 
-        Profile profile = new Profile(
-            user.getId(),
-            "닉네임",
-            null, null,
-            null, null, null, null, null, null,
-            2
-        );
-        em.persist(profile);
+        Feed feed = createFeed(user, weather, "테스트 피드");
+        persistAndClear(user, profile, weather, feed);
 
-        Weather weather = Weather.builder()
-            .forecastedAt(Instant.now())
-            .forecastAt(Instant.now())
-            .skyStatus(SkyStatus.CLEAR)
-            .latitude(BigDecimal.ONE)
-            .longitude(BigDecimal.ONE)
-            .precipitationType(PrecipitationType.NONE)
-            .temperature(20.0)
-            .temperatureMin(18.0)
-            .temperatureMax(25.0)
-            .profile(profile)
-            .build();
-        em.persist(weather);
-
-        Feed feed = new Feed(user.getId(), weather.getId(), "테스트 피드", 0, 0);
-        em.persist(feed);
-
-        em.flush();
-        em.clear();
-
-        // when
         FeedDto dto = feedRepository.findFeedDtoById(feed.getId(), user.getId());
 
-        // then
         assertThat(dto).isNotNull();
         assertThat(dto.id()).isEqualTo(feed.getId());
         assertThat(dto.content()).isEqualTo("테스트 피드");
@@ -176,4 +142,219 @@ public class FeedRepositoryImplTest {
         assertThat(result).isNull();
     }
 
+    @Test
+    @DisplayName("FeedListRequest 조건으로 FeedDto 목록 조회 성공")
+    void findFeedDtos_success() {
+        // given
+        User user = createUser("작성자2", "author2@example.com");
+        Profile profile = createProfile(user);
+        Weather weather = createWeather(profile, SkyStatus.CLEAR, PrecipitationType.NONE);
+
+        Feed feed = createFeed(user, weather, "검색 키워드 포함 피드");
+        persistAndClear(user, profile, weather, feed);
+
+        FeedListRequest request = new FeedListRequest(
+            null, null, 10, "createdAt",
+            SortDirection.DESCENDING, "키워드", SkyStatus.CLEAR, PrecipitationType.NONE, user.getId()
+        );
+
+        // when
+        List<FeedDto> result = feedRepository.findFeedDtos(request, user.getId());
+
+        // then
+        assertThat(result).hasSize(1);
+        FeedDto dto = result.get(0);
+        assertThat(dto.content()).contains("검색 키워드");
+        assertThat(dto.author().userId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("조건에 맞는 피드 개수 조회 성공")
+    void countFeeds_success() {
+        // given
+        User user = createUser("작성자3", "author3@example.com");
+        Profile profile = createProfile(user);
+        Weather weather = createWeather(profile, SkyStatus.CLEAR, PrecipitationType.RAIN);
+
+        Feed feed1 = createFeed(user, weather, "비 오는 날 피드");
+        Feed feed2 = createFeed(user, weather, "맑은 하늘 피드");
+        persistAndClear(user, profile, weather, feed1, feed2);
+
+        // when
+        long countAll = feedRepository.countFeeds(null, null, null, null);
+        long countRain = feedRepository.countFeeds(null, null, PrecipitationType.RAIN, null);
+        long countByAuthor = feedRepository.countFeeds(null, null, null, user.getId());
+
+        // then
+        assertThat(countAll).isGreaterThanOrEqualTo(2);
+        assertThat(countRain).isEqualTo(2);
+        assertThat(countByAuthor).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("잘못된 sortBy 값으로 조회 시 예외 발생")
+    void findFeedDtos_invalidSortBy() {
+        FeedListRequest request = new FeedListRequest(
+            null, null, 0,
+            "invalidSort", SortDirection.DESCENDING,
+            null, null, null, null
+        );
+
+        assertThatThrownBy(() -> feedRepository.findFeedDtos(request, UUID.randomUUID()))
+            .isInstanceOf(InvalidSortOptionException.class);
+    }
+
+    @Test
+    @DisplayName("createdAt ASC + cursor 조건으로 FeedDto 목록 조회 성공")
+    void findFeedDtos_createdAtAsc_withCursor() throws InterruptedException {
+        User user = createUser("작성자", "asc@test.com");
+        Profile profile = createProfile(user);
+        Weather weather = createWeather(profile, SkyStatus.CLEAR, PrecipitationType.NONE);
+
+        Feed feed1 = createFeed(user, weather, "피드1");
+        Thread.sleep(5);
+        Feed feed2 = createFeed(user, weather, "피드2");
+        em.flush();
+        em.clear();
+
+        String cursor = feed1.getCreatedAt().toString();
+        UUID idAfter = feed1.getId();
+
+        FeedListRequest request = new FeedListRequest(
+            cursor, idAfter, 10,
+            "createdAt", SortDirection.ASCENDING,
+            null, null, null, null
+        );
+
+        List<FeedDto> result = feedRepository.findFeedDtos(request, user.getId());
+
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("createdAt DESC + cursor 조건으로 FeedDto 목록 조회 성공")
+    void findFeedDtos_createdAtDesc_withCursor() throws InterruptedException {
+        User user = createUser("작성자", "desc@test.com");
+        Profile profile = createProfile(user);
+        Weather weather = createWeather(profile, SkyStatus.CLEAR, PrecipitationType.NONE);
+
+        Feed older = createFeed(user, weather, "이전 피드");
+        Thread.sleep(5);
+        Feed newer = createFeed(user, weather, "새 피드");
+        em.flush();
+        em.clear();
+
+        String cursor = newer.getCreatedAt().toString();
+        UUID idAfter = newer.getId();
+
+        FeedListRequest request = new FeedListRequest(
+            cursor, idAfter, 10,
+            "createdAt", SortDirection.DESCENDING,
+            null, null, null, null
+        );
+
+        List<FeedDto> result = feedRepository.findFeedDtos(request, user.getId());
+
+        assertThat(result).extracting(FeedDto::id).contains(older.getId());
+    }
+
+    @Test
+    @DisplayName("likeCount ASC + cursor 조건으로 FeedDto 목록 조회 성공")
+    void findFeedDtos_likeCountAsc_withCursor() {
+        User user = createUser("작성자", "ascLike@test.com");
+        Profile profile = createProfile(user);
+        Weather weather = createWeather(profile, SkyStatus.CLEAR, PrecipitationType.NONE);
+
+        Feed lowLike = new Feed(user.getId(), weather.getId(), "좋아요 적음", 0, 5);
+        Feed highLike = new Feed(user.getId(), weather.getId(), "좋아요 많음", 0, 10);
+        em.persist(lowLike);
+        em.persist(highLike);
+        em.flush();
+        em.clear();
+
+        String cursor = String.valueOf(lowLike.getLikeCount());
+        UUID idAfter = lowLike.getId();
+
+        FeedListRequest request = new FeedListRequest(
+            cursor, idAfter, 10,
+            "likeCount", SortDirection.ASCENDING,
+            null, null, null, null
+        );
+
+        List<FeedDto> result = feedRepository.findFeedDtos(request, user.getId());
+
+        assertThat(result).extracting(FeedDto::id).contains(highLike.getId());
+    }
+
+    @Test
+    @DisplayName("likeCount DESC + cursor 조건으로 FeedDto 목록 조회 성공")
+    void findFeedDtos_likeCountDesc_withCursor() {
+        User user = createUser("작성자", "descLike@test.com");
+        Profile profile = createProfile(user);
+        Weather weather = createWeather(profile, SkyStatus.CLEAR, PrecipitationType.NONE);
+
+        Feed highLike = new Feed(user.getId(), weather.getId(), "좋아요 많음", 0, 10);
+        Feed lowLike = new Feed(user.getId(), weather.getId(), "좋아요 적음", 0, 5);
+        em.persist(highLike);
+        em.persist(lowLike);
+        em.flush();
+        em.clear();
+
+        String cursor = String.valueOf(highLike.getLikeCount());
+        UUID idAfter = highLike.getId();
+
+        FeedListRequest request = new FeedListRequest(
+            cursor, idAfter, 10,
+            "likeCount", SortDirection.DESCENDING,
+            null, null, null, null
+        );
+
+        List<FeedDto> result = feedRepository.findFeedDtos(request, user.getId());
+
+        assertThat(result).extracting(FeedDto::id).contains(lowLike.getId());
+    }
+
+    private User createUser(String name, String email) {
+        User user = new User(name, email, "password", Role.USER);
+        em.persist(user);
+        return user;
+    }
+
+    private Profile createProfile(User user) {
+        Profile profile = new Profile(user.getId(), "닉네임", null, null,
+            null, null, null, null, null, null, 2);
+        em.persist(profile);
+        return profile;
+    }
+
+    private Weather createWeather(Profile profile, SkyStatus skyStatus, PrecipitationType type) {
+        Weather weather = Weather.builder()
+            .forecastedAt(Instant.now())
+            .forecastAt(Instant.now())
+            .skyStatus(skyStatus)
+            .latitude(BigDecimal.ONE)
+            .longitude(BigDecimal.ONE)
+            .precipitationType(type)
+            .temperature(20.0)
+            .temperatureMin(18.0)
+            .temperatureMax(25.0)
+            .profile(profile)
+            .build();
+        em.persist(weather);
+        return weather;
+    }
+
+    private Feed createFeed(User user, Weather weather, String content) {
+        Feed feed = new Feed(user.getId(), weather.getId(), content, 0, 0);
+        em.persist(feed);
+        return feed;
+    }
+
+    private void persistAndClear(Object... entities) {
+        for (Object entity : entities) {
+            em.persist(entity);
+        }
+        em.flush();
+        em.clear();
+    }
 }

--- a/src/test/java/com/sprint/ootd5team/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/sprint/ootd5team/feed/service/FeedServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -191,6 +192,41 @@ public class FeedServiceTest {
         assertThat(response.hasNext()).isTrue();
         assertThat(response.nextCursor()).isEqualTo(feed1.createdAt().toString());
         assertThat(response.nextIdAfter()).isEqualTo(feed1.id());
+    }
+
+    @Test
+    @DisplayName("피드 단건 조회 성공")
+    void getFeed_success() {
+        // given
+        UUID feedId = UUID.randomUUID();
+        FeedDto mockDto = new FeedDto(
+            feedId, Instant.now(), Instant.now(), testAuthor, testWeather,
+            List.of(), "테스트 피드", 10, 2, false
+        );
+
+        given(feedRepository.findFeedDtoById(feedId, userId)).willReturn(mockDto);
+
+        // when
+        FeedDto result = feedService.getFeed(feedId, userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(feedId);
+        assertThat(result.content()).isEqualTo("테스트 피드");
+        verify(feedRepository).findFeedDtoById(feedId, userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 피드 조회 시 예외 발생")
+    void getFeed_notFound() {
+        // given
+        UUID feedId = UUID.randomUUID();
+        given(feedRepository.findFeedDtoById(feedId, userId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> feedService.getFeed(feedId, userId))
+            .isInstanceOf(FeedNotFoundException.class);
+        verify(feedRepository).findFeedDtoById(feedId, userId);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->
CODEITSB03-39, CODEITSB03-122

## 📝 요약(Summary)
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
피드 댓글 등록 기능입니다.

댓글 등록 시, Feed의 `commentCount` 값이 1 증가하고 댓글 데이터가 `FeedComment` 테이블에 추가됩니다.

## 🛠️ PR 변경 사항
<!-- 어떤 변경 사항이 있나요? -->
- `CommentCreateRequest`의 `feedId` 값이 프론트에서 중복적으로 데이터 요청에 포함되어 제거했습니다.
- `ProfileMapper`에 `AuthoDto`로 변환하는 메서드를 추가했습니다. (`CommentDto`내에 `AuthorDto` 필요)
- 피드 관련 테스트 커버리지 보완했습니다.

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x]  기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [x]  예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트

- [x]  테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다
- [x]  실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)
<img width="920" height="968" alt="test-coverage" src="https://github.com/user-attachments/assets/a1d1890d-951f-4c6d-aba1-06c1b3400aa9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 특정 피드 경로로 댓글을 등록할 수 있게 되었습니다 (POST /feeds/{feedId}/comments).
  * 댓글 생성 시 해당 피드의 댓글 수가 자동으로 증가합니다.
  * 댓글 응답에 작성자 정보(작성자 프로필)가 포함됩니다.
* **리팩터링**
  * 피드·작성자 검증과 댓글 매핑 흐름을 정비해 안정성을 높였습니다.
* **테스트**
  * 컨트롤러·서비스·매퍼·리포지토리 테스트를 보강해 성공 및 예외 시나리오를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->