### PR TITLE
bugfix: 계정잠금, 권한 변경시 해당 사용자가 로그아웃되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
+++ b/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
@@ -57,6 +57,8 @@ public class AuthService {
         Role newRole = Role.valueOf(request.role());
         user.updateRole(newRole);
 
+        jwtRegistry.invalidateJwtInformationByUserId(userId);
+
         eventPublisher.publishEvent(new RoleUpdatedEvent(user.getId(), oldRole.name(), newRole.name()));
 
         return userMapper.toDto(userRepository.save(user));

--- a/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
+++ b/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
@@ -57,9 +57,9 @@ public class AuthService {
         Role newRole = Role.valueOf(request.role());
         user.updateRole(newRole);
 
-        eventPublisher.publishEvent(new RoleUpdatedEvent(user.getId(), oldRole.name(), newRole.name()));
         User save = userRepository.save(user);
         jwtRegistry.invalidateJwtInformationByUserId(userId);
+        eventPublisher.publishEvent(new RoleUpdatedEvent(user.getId(), oldRole.name(), newRole.name()));
         return userMapper.toDto(save);
     }
 

--- a/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
+++ b/src/main/java/com/sprint/ootd5team/base/security/service/AuthService.java
@@ -57,11 +57,10 @@ public class AuthService {
         Role newRole = Role.valueOf(request.role());
         user.updateRole(newRole);
 
-        jwtRegistry.invalidateJwtInformationByUserId(userId);
-
         eventPublisher.publishEvent(new RoleUpdatedEvent(user.getId(), oldRole.name(), newRole.name()));
-
-        return userMapper.toDto(userRepository.save(user));
+        User save = userRepository.save(user);
+        jwtRegistry.invalidateJwtInformationByUserId(userId);
+        return userMapper.toDto(save);
     }
 
     /**

--- a/src/main/java/com/sprint/ootd5team/domain/user/service/UserService.java
+++ b/src/main/java/com/sprint/ootd5team/domain/user/service/UserService.java
@@ -153,9 +153,10 @@ public class UserService {
         log.info("[user]계정 잠금여부 업데이트 메서드 시작 userId:{}, request:{}", userId, request);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         user.updateLock(request.locked());
+        User save = userRepository.save(user);
         jwtRegistry.invalidateJwtInformationByUserId(userId);
         log.debug("[user] 계정잠금 완료");
-        return userMapper.toDto(userRepository.save(user));
+        return userMapper.toDto(save);
 
     }
 }

--- a/src/main/java/com/sprint/ootd5team/domain/user/service/UserService.java
+++ b/src/main/java/com/sprint/ootd5team/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.sprint.ootd5team.domain.user.service;
 
 import com.sprint.ootd5team.base.exception.user.UserAlreadyExistException;
 import com.sprint.ootd5team.base.exception.user.UserNotFoundException;
+import com.sprint.ootd5team.base.security.JwtRegistry;
 import com.sprint.ootd5team.domain.profile.entity.Profile;
 import com.sprint.ootd5team.domain.profile.repository.ProfileRepository;
 import com.sprint.ootd5team.domain.user.dto.UserDto;
@@ -35,6 +36,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserMapper userMapper;
     private final UserRepositoryCustom userRepositoryCustom;
+    private final JwtRegistry jwtRegistry;
 
 
     /**
@@ -151,6 +153,7 @@ public class UserService {
         log.info("[user]계정 잠금여부 업데이트 메서드 시작 userId:{}, request:{}", userId, request);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         user.updateLock(request.locked());
+        jwtRegistry.invalidateJwtInformationByUserId(userId);
         log.debug("[user] 계정잠금 완료");
         return userMapper.toDto(userRepository.save(user));
 


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
계정잠금, 권한 변경시 해당 사용자가 로그아웃되지 않는 버그 수정

## 🛠️ PR 변경 사항
<!-- 어떤 변경 사항이 있나요? -->
- 계정잠금시 jwtRegistry.invalidateJwtInformationByUserId(userId) 을 실행하도록 설정


## 📸스크린샷 (선택)
<!-- 관련 스크린샷을 첨부해 주세요 -->
<img width="719" height="611" alt="image" src="https://github.com/user-attachments/assets/390a9f83-bf25-4215-8546-8d72b73c0709" />


## 💬 공유사항
<!-- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x]  기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [x]  예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트

- [ ]  테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [x]  실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 사용자 역할 변경 시 변경 내용을 저장한 직후 해당 계정의 기존 로그인 토큰(JWT)이 즉시 무효화되어 보안이 강화됩니다. 변경 후 재로그인이 필요할 수 있습니다.
  - 계정 잠금·해제 시 변경 내용을 저장한 뒤 해당 계정의 모든 활성 세션(JWT)이 자동으로 만료되어 여러 기기에서의 비정상 접근을 차단합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->